### PR TITLE
Using IHC name + position as entity name.

### DIFF
--- a/custom_components/ihc/ihcdevice.py
+++ b/custom_components/ihc/ihcdevice.py
@@ -48,6 +48,8 @@ class IHCDevice(Entity):
                 if self.ihc_position:
                     self.device_name += f" ({self.ihc_position})"
                 self.device_model = product["model"]
+                # Update entity name to the more user friendly "name + position" device name instead of the group_id composite.
+                self._name = self.device_name
         else:
             self.ihc_name = ""
             self.ihc_note = ""


### PR DESCRIPTION
Default entity names are now the same as  the device names, which is the IHC style + position instead of the less user friendly "group_id" name. Names can still be customized in HA afterwards.