### PR TITLE
Added support for stateless airlink buttons.

### DIFF
--- a/custom_components/ihc/button.py
+++ b/custom_components/ihc/button.py
@@ -1,0 +1,66 @@
+"""Support for IHC buttons."""
+import logging
+
+from ihcsdk.ihccontroller import IHCController
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from typing import Any
+
+from .const import DOMAIN, IHC_CONTROLLER
+from .ihcdevice import IHCDevice
+from .util import async_pulse
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Load IHC buttons based on a config entry."""
+    controller_id: str = str(config_entry.unique_id)
+    controller_data = hass.data[DOMAIN][controller_id]
+    ihc_controller: IHCController = controller_data[IHC_CONTROLLER]
+    buttons = []
+    if "button" in controller_data and controller_data["button"]:
+        for name, device in controller_data["button"].items():
+            ihc_id = device["ihc_id"]
+            product = device["product"]
+            switch = IHCButton(
+                ihc_controller,
+                controller_id,
+                name,
+                ihc_id,
+                product,
+            )
+            buttons.append(switch)
+        async_add_entities(buttons)
+
+
+class IHCButton(IHCDevice, ButtonEntity):
+    """Representation of an IHC stateless button."""
+
+    def __init__(
+        self,
+        ihc_controller: IHCController,
+        controller_id: str,
+        name: str,
+        ihc_id: int,
+        product=None,
+    ) -> None:
+        """Initialize the IHC button."""
+        super().__init__(ihc_controller, controller_id, name, ihc_id, product)
+        self._state = False
+
+    async def async_press(self) -> None:
+        """Send button pulse to IHC."""
+        await async_pulse(self.hass, self.ihc_controller, self.ihc_id)
+
+    def on_ihc_change(self, ihc_id, value):
+        """Handle IHC resource change."""
+        self._state = value
+        self.schedule_update_ha_state()

--- a/custom_components/ihc/const.py
+++ b/custom_components/ihc/const.py
@@ -20,6 +20,7 @@ CONF_ON_ID = "on_id"
 CONF_POSITION = "position"
 CONF_SENSOR = "sensor"
 CONF_SWITCH = "switch"
+CONF_BUTTON = "button"
 CONF_XPATH = "xpath"
 
 DOMAIN = "ihc"
@@ -31,6 +32,7 @@ IHC_PLATFORMS = (
     Platform.LIGHT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.BUTTON
 )
 
 MANUAL_SETUP_YAML = "ihc_manual_setup.yaml"

--- a/custom_components/ihc/ihc_auto_setup.yaml
+++ b/custom_components/ihc/ihc_auto_setup.yaml
@@ -130,3 +130,14 @@ switch:
   # Wireless mobile relay
   - xpath: './/product_airlink[@product_identifier="_0x4204"]'
     node: "airlink_relay"
+
+button:
+  # Wireless Combi relay 2 buttons
+  - xpath: './/product_airlink[@product_identifier="_0x4101"]'
+    node: "airlink_input"    
+  # Wireless Combi relay 4 buttons
+  - xpath: './/product_airlink[@product_identifier="_0x4102"]'
+    node: "airlink_input"
+  # Wireless Combi relay 6 buttons
+  - xpath: './/product_airlink[@product_identifier="_0x4103"]'
+    node: "airlink_input"    

--- a/custom_components/ihc/ihcdevice.py
+++ b/custom_components/ihc/ihcdevice.py
@@ -48,6 +48,8 @@ class IHCDevice(Entity):
                 if self.ihc_position:
                     self.device_name += f" ({self.ihc_position})"
                 self.device_model = product["model"]
+                # Update entity name to the more user friendly "name + position" device name instead of the group_id composite.
+                self._name = product["entity_name"] or self.device_name
         else:
             self.ihc_name = ""
             self.ihc_note = ""

--- a/custom_components/ihc/manual_setup.py
+++ b/custom_components/ihc/manual_setup.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_POSITION,
     CONF_SENSOR,
     CONF_SWITCH,
+    CONF_BUTTON,
     DOMAIN,
     IHC_PLATFORMS,
     MANUAL_SETUP_YAML,
@@ -101,6 +102,9 @@ MANUAL_SETUP_SCHEMA = vol.Schema(
                                 cv.ensure_list, [vol.All(SENSOR_SCHEMA, validate_name)]
                             ),
                             vol.Optional(CONF_SWITCH, default=[]): vol.All(
+                                cv.ensure_list, [vol.All(SWITCH_SCHEMA, validate_name)]
+                            ),
+                            vol.Optional(CONF_BUTTON, default=[]): vol.All(
                                 cv.ensure_list, [vol.All(SWITCH_SCHEMA, validate_name)]
                             ),
                         }

--- a/hacs.json
+++ b/hacs.json
@@ -5,7 +5,8 @@
         "binary_sensor",
         "light",
         "sensor",
-        "switch"
+        "switch",
+        "button"
     ],
     "iot_class": "Local Push",
     "homeassistant": "0.118.0"


### PR DESCRIPTION
Support for toggle buttons such as LK FUGA airlink. These buttons send an event rather than a state switch and cannot be properly represented as switches, since a 1:1 relation with an outlet toggle cannot be guaranteed.